### PR TITLE
Bump Interpolations and SatelliteToolbox compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EPPIonization"
 uuid = "1f1cae16-1f2d-462a-a280-9fd812a581a0"
 authors = ["fgasdia <fgasdia@noreply.github.com>"]
-version = "0.0.5"
+version = "0.0.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -19,9 +19,9 @@ FIRITools = "0.0.4"
 GPI = "0.0.2"
 GeographicLib = "0.4"
 HDF5 = "0.15"
-Interpolations = "= 0.13.2"  # Until a bug is fixed in SatelliteToolbox.jl v0.9
+Interpolations = "0.13.3"
 LMPTools = "0.0.7"
-SatelliteToolbox = "0.9"
+SatelliteToolbox = "0.9.1"
 TypedTables = "1.2"
 
 [extras]


### PR DESCRIPTION
Bump compat of SatelliteToolbox.jl to `v0.9.1` and Interpolations.jl to `v0.13.3`. See https://github.com/JuliaSpace/SatelliteToolbox.jl/issues/58

Also bump project version to `v0.0.6`.